### PR TITLE
Twig 3.3.7 update 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.1",
         "bramus/router": "dev-master",
-        "twig/twig": "~3.3",
+        "twig/twig": "^3.0",
         "shanemcc/php-db": "0.5"
     },
     "autoload": {

--- a/src/BootableImageTwigLoader.php
+++ b/src/BootableImageTwigLoader.php
@@ -1,5 +1,10 @@
 <?php
 
+use Twig\Loader\LoaderInterface as Twig_LoaderInterface;
+use Twig\Source as Twig_Source;
+use Twig\Error\LoaderError as Twig_Error_Loader;
+use Twig\TwigFunction as Twig_Function;
+
 class BootableImageTwigLoader implements Twig_LoaderInterface {
 	private $db;
 	private $cache = [];
@@ -8,25 +13,25 @@ class BootableImageTwigLoader implements Twig_LoaderInterface {
 		$this->db = $db;
 	}
 
-	public function getSourceContext($name) {
+	public function getSourceContext(string $name): Twig_Source {
 		[$data, $time] = $this->getTemplate($name);
 
 		return new Twig_Source($data, $name);
 	}
 
-	public function getCacheKey($name) {
+	public function getCacheKey(string $name): string {
 		[$data, $time] = $this->getTemplate($name);
 
 		return $name;
 	}
 
-	public function isFresh($name, $time) {
+	public function isFresh(string $name, int $time): bool {
 		[$data, $lasttime] = $this->getTemplate($name);
 
 		return ($time >= $lasttime);
 	}
 
-	public function exists($name) {
+	public function exists(string $name) {
 		try {
 			return $this->getTemplate($name) !== FALSE;
 		} catch (Twig_Error_Loader $ex) {

--- a/src/classes/BootableImage.php
+++ b/src/classes/BootableImage.php
@@ -2,6 +2,7 @@
 
 use shanemcc\phpdb\DBObject;
 use shanemcc\phpdb\ValidationFailed;
+use Twig\TwigFunction as Twig_Function;
 
 class BootableImage extends DBObject {
 	protected static $_fields = ['id' => NULL,

--- a/src/classes/Server.php
+++ b/src/classes/Server.php
@@ -2,6 +2,7 @@
 
 use shanemcc\phpdb\DBObject;
 use shanemcc\phpdb\ValidationFailed;
+use Twig\TwigFunction as Twig_Function;
 
 class Server extends DBObject {
 	protected static $_fields = ['id' => NULL,


### PR DESCRIPTION
We updated twig to 3.3.7 and did some additional changes to get it working on Ubuntu 20.04 and the default provided PHP 7.4